### PR TITLE
Rewrite application to be an ets counter app

### DIFF
--- a/Docker-Cheat-Sheet.md
+++ b/Docker-Cheat-Sheet.md
@@ -8,6 +8,10 @@
 
     $ docker rmi $(docker images -f dangling=true -q)
 
+* Attach to running docker
+
+    $ docker exec -i -t NameOrId /bin/sh
+
 ## Core generation
 
   * `/proc/sys/core_pattern` is clearly persisted on the host. Taking note of

--- a/README-CERTS.md
+++ b/README-CERTS.md
@@ -1,0 +1,23 @@
+## Generating Certificate
+
+Generate certificates in subdirectory `ssl`.
+
+### Root CA
+
+    $ openssl genrsa -out dockerwatch-ca.key 4096
+
+    $ openssl req -x509 -new -nodes -key dockerwatch-ca.key -sha256 -days 1024 -out dockerwatch-ca.pem
+
+### Server Certificate
+
+    $ openssl genrsa -out dockerwatch-server.key 4096
+
+Certificate signing request
+
+    $ openssl req -new -key dockerwatch-server.key -out dockerwatch-server.csr
+
+The most important field: `Common Name (eg, YOUR name) []: localhost`. We use localhost in this example.
+
+### Sign it
+
+    $ openssl x509 -req -in dockerwatch-server.csr -CA dockerwatch-ca.pem -CAkey dockerwatch-ca.key -CAcreateserial -out dockerwatch-server.pem -days 500 -sha256

--- a/README.md
+++ b/README.md
@@ -112,13 +112,13 @@ For some more details of what this command does, wee [README-CERTS.md](README-CE
 
 We start the image in docker container by issuing the following command.
 
-    $ docker run -d -p 8443:8443 --volume="$PWD/ssl:/dockerwatch/lib/dockerwatch-1.0.0/priv/ssl" --log-driver=syslog erlang-dockerwatch
+    $ docker run -d -p 8443:8443 --volume="$PWD/ssl:/etc/ssl/certs" --log-driver=syslog erlang-dockerwatch
     870f979c5b4cdb7a1ba930b020043f50fa7457bf787237706fb27eefaf5fe61d
 
 Let's parse some of the input.
 
  * `-p 8443:8443`, exposes port `8443` from the container to our localhost
- * `--volume="$PWD/ssl:/dockerwatch/lib/dockerwatch-1.0.0/priv/ssl"`, mounts our local directory with certificates in
+ * `--volume="$PWD/ssl:/etc/ssl/certs"`, mounts our local directory with certificates in
    the container.
  * `--log-driver=syslog`, will log all data from stdout in the container to our local syslog.
 
@@ -143,9 +143,22 @@ Fetch container IP Address from container id:
     $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 870f979c5b4c
     172.17.0.2
 
-Test with curl:
+Test https with curl:
 
     $ curl --cacert ssl/dockerwatch-ca.pem -i -H "Accept: application/json" https://localhost:8443
+    HTTP/1.1 200 OK
+    server: Cowboy
+    date: Tue, 21 Feb 2017 10:57:20 GMT
+    content-length: 17
+    content-type: application/json
+    vary: accept
+    access-control-allow-origin: *
+    
+    {"hello":"world"}
+
+Test http with curl:
+
+    $ curl --cacert ssl/dockerwatch-ca.pem -i -H "Accept: application/json" http://172.17.0.2:8080
     HTTP/1.1 200 OK
     server: Cowboy
     date: Tue, 21 Feb 2017 10:57:20 GMT

--- a/README.md
+++ b/README.md
@@ -143,28 +143,40 @@ Fetch container IP Address from container id:
     $ docker inspect --format='{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' 870f979c5b4c
     172.17.0.2
 
-Test https with curl:
+Create a counter called `cnt` using https with curl:
 
-    $ curl --cacert ssl/dockerwatch-ca.pem -i -H "Accept: application/json" https://localhost:8443
-    HTTP/1.1 200 OK
+    $ curl --cacert ssl/dockerwatch-ca.pem -i -H "Content-Type: application/json" -X POST -d "" https://localhost:8443/cnt
+    HTTP/1.1 204 No Content
     server: Cowboy
-    date: Tue, 21 Feb 2017 10:57:20 GMT
-    content-length: 17
-    content-type: application/json
+    date: Wed, 22 Feb 2017 13:12:54 GMT
+    content-length: 0
+    content-type: text/html
     vary: accept
-    access-control-allow-origin: *
-    
-    {"hello":"world"}
 
-Test http with curl:
+Read all counters using https with curl as json:
 
-    $ curl --cacert ssl/dockerwatch-ca.pem -i -H "Accept: application/json" http://172.17.0.2:8080
-    HTTP/1.1 200 OK
-    server: Cowboy
-    date: Tue, 21 Feb 2017 10:57:20 GMT
-    content-length: 17
-    content-type: application/json
-    vary: accept
-    access-control-allow-origin: *
-    
-    {"hello":"world"}
+    curl --cacert ssl/dockerwatch-ca.pem -H "Accept: application/json" https://localhost:8443
+    ["cnt"]
+
+Read the counter `cnt` using https with curl as json:
+
+    curl --cacert ssl/dockerwatch-ca.pem -H "Accept: application/json" https://localhost:8443/cnt
+    {"cnt":0}
+
+Increment the counter `cnt` using http with curl:
+
+    curl -H "Content-Type: application/json" -X POST -d '{}' http://172.17.0.2:8080/cnt
+
+Read the counter `cnt` using http with curl as text:
+
+    curl -H "Accept: text/plain" http://172.17.0.2:8080/cnt
+    1
+
+Increment the counter `cnt` by 20 using http with curl:
+
+    curl -H "Content-Type: application/json" -X POST -d '{"value":20}' http://172.17.0.2:8080/cnt
+
+Read the counter `cnt` using http with curl as text:
+
+    curl -H "Accept: text/plain" http://172.17.0.2:8080/cnt
+    21

--- a/README.md
+++ b/README.md
@@ -104,32 +104,9 @@ What happened?
 
 Generate certificates in subdirectory `ssl`.
 
-    $ mkdir ssl && cd ssl
+    $ ./create-certs
 
-### Root CA
-
-    $ openssl genrsa -out dockerwatch-ca.key 4096
-
-    $ openssl req -x509 -new -nodes -key dockerwatch-ca.key -sha256 -days 1024 -out dockerwatch-ca.pem
-
-### Server Certificate
-
-    $ openssl genrsa -out dockerwatch-server.key 4096
-
-Certificate signing request
-
-    $ openssl req -new -key dockerwatch-server.key -out dockerwatch-server.csr
-
-The most important field: `Common Name (eg, YOUR name) []: localhost`. We use localhost in this example.
-
-### Sign it
-
-    $ openssl x509 -req -in dockerwatch-server.csr -CA dockerwatch-ca.pem -CAkey dockerwatch-ca.key -CAcreateserial -out dockerwatch-server.pem -days 500 -sha256
-
-
-Once done with the certificates, change directory to the top directory of this repository.
-
-    $ cd ..
+For some more details of what this command does, wee [README-CERTS.md](README-CERTS.md)
 
 ## Running the Erlang Application
 

--- a/alpine/run/Dockerfile
+++ b/alpine/run/Dockerfile
@@ -4,6 +4,7 @@ FROM alpine:3.3
 COPY artifacts/dockerwatch /dockerwatch
 
 # Expose relevant ports
+EXPOSE 8080
 EXPOSE 8443
 
 CMD ["/dockerwatch/bin/dockerwatch", "foreground"]

--- a/create-certs
+++ b/create-certs
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+if [ ! -d ssl ]; then
+    mkdir ssl
+fi
+
+# Create the root CA (Certificate Authority)
+openssl genrsa -out ssl/dockerwatch-ca.key 4096
+
+## Certificate signing request for root CA
+echo "!!! \"Common Name\" should be left blank"
+openssl req -x509 -new -nodes -key ssl/dockerwatch-ca.key -sha256 -days 1024 -out ssl/dockerwatch-ca.pem
+
+# Create the server certificate
+openssl genrsa -out ssl/dockerwatch-server.key 4096
+
+## Certificate signing request for server certificate
+echo "!!! \"Common Name\" has to be the name that you use to connect to the server, eg. localhost "
+openssl req -new -key ssl/dockerwatch-server.key -out ssl/dockerwatch-server.csr
+
+## Sign the server certificate using the root CA
+openssl x509 -req -in ssl/dockerwatch-server.csr -CA ssl/dockerwatch-ca.pem -CAkey ssl/dockerwatch-ca.key -CAcreateserial -out ssl/dockerwatch-server.pem -days 500 -sha256

--- a/create-image
+++ b/create-image
@@ -1,5 +1,5 @@
 #!/bin/sh
-
-docker build -t build_erlang-dockerwatch --file=alpine/build/Dockerfile .
-docker run --rm --volume="$PWD/alpine/run/artifacts:/artifacts" build_erlang-dockerwatch
+ 
+docker build --build-arg https_proxy=$HTTP_PROXY --build-arg http_proxy=$HTTP_PROXY --build-arg HTTP_PROXY=$HTTP_PROXY --build-arg HTTPS_PROXY=$HTTP_PROXY --build-arg NO_PROXY=$NO_PROXY --build-arg no_proxy=$NO_PROXY -t build_erlang-dockerwatch --file=alpine/build/Dockerfile .
+docker run -e http_proxy=$HTTP_PROXY -e https_proxy=$HTTP_PROXY -e HTTP_PROXY=$HTTP_PROXY -e HTTPS_PROXY=$HTTP_PROXY -e NO_PROXY=$NO_PROXY -e no_proxy=$NO_PROXY --rm --volume="$PWD/alpine/run/artifacts:/artifacts" build_erlang-dockerwatch
 docker build -t erlang-dockerwatch alpine/run/

--- a/dockerwatch/src/dockerwatch.erl
+++ b/dockerwatch/src/dockerwatch.erl
@@ -1,0 +1,45 @@
+%%
+%% Copyright (C) 2014 Björn-Egil Dahlberg
+%%
+%% File:    dockerwatch.erl
+%% Author:  Björn-Egil Dahlberg
+%% Created: 2014-09-10
+%%
+
+-module(dockerwatch).
+
+-export([start_link/0, all/0, create/1, get/1, increment/2, decrement/2]).
+
+-type counter() :: binary().
+
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    {ok, spawn_link(fun() -> ets:new(?MODULE, [named_table, public]),
+                    receive after infinity -> ok end end)}.
+
+-spec all() -> [counter()].
+all() ->
+    ets:select(?MODULE, [{{'$1','_'},[],['$1']}]).
+
+-spec create(counter()) -> ok | already_exists.
+create(CounterName) ->
+    case ets:insert_new(?MODULE, {CounterName, 0}) of
+        true ->
+            ok;
+        false ->
+            already_exists
+    end.
+
+-spec get(counter()) -> integer().
+get(CounterName) ->
+    ets:lookup_element(?MODULE, CounterName, 2).
+
+-spec increment(counter(), integer()) -> ok.
+increment(CounterName, Howmuch) ->
+    _ = ets:update_counter(?MODULE, CounterName, [{2, Howmuch}]),
+    ok.
+
+-spec decrement(counter(), integer()) -> ok.
+decrement(CounterName, Howmuch) ->
+    _ = ets:update_counter(?MODULE, CounterName, [{2, -1 * Howmuch}]),
+    ok.

--- a/dockerwatch/src/dockerwatch_app.erl
+++ b/dockerwatch/src/dockerwatch_app.erl
@@ -13,15 +13,6 @@
 %% API.
 
 start(_Type, _Args) ->
-    Dispatch = cowboy_router:compile([
-	    {'_', [{"/", dockerwatch_handler, []}]}
-	]),
-    PrivDir = code:priv_dir(dockerwatch),
-    Opts = [{port, 8443},
-            {cacertfile, filename:join(PrivDir,"ssl/dockerwatch-ca.pem")},
-            {certfile, filename:join(PrivDir,"ssl/dockerwatch-server.pem")},
-            {keyfile, filename:join(PrivDir,"ssl/dockerwatch-server.key")}],
-    {ok, _} = cowboy:start_https(https, 100, Opts, [{env, [{dispatch, Dispatch}]}]),
     dockerwatch_sup:start_link().
 
 stop(_State) ->

--- a/dockerwatch/src/dockerwatch_handler.erl
+++ b/dockerwatch/src/dockerwatch_handler.erl
@@ -9,7 +9,10 @@
 -module(dockerwatch_handler).
 
 -export([init/3]).
+-export([allowed_methods/2]).
+-export([content_types_accepted/2]).
 -export([content_types_provided/2]).
+-export([handle_post/2]).
 -export([to_html/2]).
 -export([to_json/2]).
 -export([to_text/2]).
@@ -17,28 +20,84 @@
 init(_Transport, _Req, []) ->
     {upgrade, protocol, cowboy_rest}.
 
+%% Which HTTP methods are allowed
+allowed_methods(Req, State) ->
+    {[<<"GET">>, <<"POST">>], Req, State}.
+
+%% Which content types are accepted by POST/PUT requests
+content_types_accepted(Req, State) ->
+    {[{{<<"application">>, <<"json">>, []}, handle_post}],
+     Req, State}.
+
+%% Handle the POST/PUT request
+handle_post(Req, State) ->
+    case cowboy_req:binding(counter_name, Req) of
+        {undefined, Req2} ->
+            {false, Req2, State};
+        {Name, Req2} ->
+            case cowboy_req:has_body(Req2) of
+                true ->
+                    {ok, Body, Req3} = cowboy_req:body(Req2),
+                    Json = jsone:decode(Body),
+                    ActionBin = maps:get(<<"action">>, Json, <<"increment">>),
+                    Value = maps:get(<<"value">>, Json, 1),
+                    Action = list_to_atom(binary_to_list(ActionBin)),
+                    ok = dockerwatch:Action(Name, Value),
+                    {true, Req3, State};
+                false ->
+                    ok = dockerwatch:create(Name),
+                    {true, Req2, State}
+            end
+    end.
+
+%% Which content types we handle for GET/HEAD requests
 content_types_provided(Req, State) ->
     {[{<<"text/html">>, to_html},
       {<<"application/json">>, to_json},
       {<<"text/plain">>, to_text}
     ], Req, State}.
 
+
+%% Return counters/counter as json
+to_json(Req, State) ->
+    Resp = case cowboy_req:binding(counter_name, Req) of
+               {undefined, _Req2} ->
+                   dockerwatch:all();
+               {Counter, _Req2} ->
+                   #{ Counter => dockerwatch:get(Counter) }
+           end,
+    {jsone:encode(Resp), Req, State}.
+
+%% Return counters/counter as plain text
+to_text(Req, State) ->
+    Resp = case cowboy_req:binding(counter_name, Req) of
+               {undefined, _Req2} ->
+                   [io_lib:format("~s~n",[Counter]) || Counter <- dockerwatch:all()];
+               {Counter, _Req2} ->
+                   io_lib:format("~p",[dockerwatch:get(Counter)])
+           end,
+    {Resp, Req, State}.
+
+%% Return counters/counter as html
 to_html(Req, State) ->
-    Body = <<"<html>
+    Body = case cowboy_req:binding(counter_name, Req) of
+               {undefined, _Req2} ->
+                   Counters = dockerwatch:all(),
+                   ["<ul>\n",
+                    [io_lib:format("<li>~s</li>\n", [Counter]) || Counter <- Counters],
+                    "</ul>\n"];
+               {Counter, _Req2} ->
+                   Value = dockerwatch:get(Counter),
+                   io_lib:format("~s = ~p",[Counter, Value])
+           end,
+    {[html_head(),Body,html_tail()], Req, State}.
+
+html_head() ->
+    <<"<html>
     <head>
     <meta charset=\"utf-8\">
-    <title>REST Hello World!</title>
-    </head>
-    <body>
-    <p>REST Hello World as HTML!</p>
-    </body>
-    </html>">>,
-    {Body, Req, State}.
-
-to_json(Req, State) ->
-    Ds = #{ <<"hello">> => <<"world">> },
-    Req1 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>, <<"*">>, Req),
-    {jsone:encode(Ds), Req1, State}.
-
-to_text(Req, State) ->
-    {<<"REST Hello World as text!">>, Req, State}.
+    <title>dockerwatch</title>
+    </head>">>.
+html_tail() ->
+    <<"</body>
+    </html>">>.

--- a/dockerwatch/src/dockerwatch_sup.erl
+++ b/dockerwatch/src/dockerwatch_sup.erl
@@ -23,7 +23,7 @@ init([]) ->
     CertsDir = "/etc/ssl/certs/",
 
     Dispatch = cowboy_router:compile([
-	    {'_', [{"/", dockerwatch_handler, []}]}
+	    {'_', [{"/[:counter_name]", dockerwatch_handler, []}]}
 	]),
 
     HTTPS = ranch:child_spec(
@@ -41,7 +41,9 @@ init([]) ->
              cowboy_protocol,
              [{env, [{dispatch, Dispatch}]}]),
 
+    Counter = {dockerwatch, {dockerwatch, start_link, []},
+               permanent, 5000, worker, [dockerwatch]},
 
-    Procs = [HTTP, HTTPS],
+    Procs = [Counter, HTTP, HTTPS],
 
     {ok, {{one_for_one, 10, 10}, Procs}}.


### PR DESCRIPTION
This PR changes the demo application to be a counter application.

It also fixes some problems with running the image creations scripts behind http proxies and exposes the application api through http as well as https.