### PR TITLE
Correct minor typos

### DIFF
--- a/Docker-Cheat-Sheet.md
+++ b/Docker-Cheat-Sheet.md
@@ -2,20 +2,20 @@
 
 * Remove all containers that are not running:
 
-    $ docker rm `docker ps -aq -f status=exited`
+        $ docker rm $(docker ps -aq -f status=exited)
 
-* Remove dangling images
+* Remove dangling images:
 
-    $ docker rmi $(docker images -f dangling=true -q)
+        $ docker rmi $(docker images -f dangling=true -q)
 
-* Attach to running docker
+* Attach to running docker:
 
-    $ docker exec -i -t NameOrId /bin/sh
+        $ docker exec -i -t NameOrId /bin/sh
 
 ## Core generation
 
   * `/proc/sys/core_pattern` is clearly persisted on the host. Taking note of
-    it's content before starting any endeavour is therefore highly encouraged.
+    its content before starting any endeavour is therefore highly encouraged.
   * dockers `--privileged` is necessary for a gdb session to catch the stack,
     without privileges, gdb just complains about No stack. Google still is
     hardly knowledgeable about this phenomenon...


### PR DESCRIPTION
The first example was not shown correctly, because the Markdown conversion ate the backquotes. Rewrite it with in the `$(...)` style as in the second example.